### PR TITLE
Add reset signal

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -67,7 +67,17 @@ impl Cpu {
         }
 
         let mut env = Environment::new(&mut self.state, sys);
-        if env.state.nmi_pending {
+        if env.state.reset_pending {
+            env.state.reset_pending = false;
+            env.state.nmi_pending = false;
+            env.state.halted = false;
+            env.state.reg.set_pc(0x0000);
+            env.state.reg.set8(Reg8::I, 0x00);
+            env.state.reg.set8(Reg8::R, 0x00);
+            env.state.reg.set_interrupts(false);
+            env.state.reg.set_interrupt_mode(0);
+        }
+        else if env.state.nmi_pending {
             env.state.nmi_pending = false;
             env.state.halted = false;
             env.state.reg.start_nmi();
@@ -116,12 +126,17 @@ impl Cpu {
 
     /// Returns if the Cpu has executed a HALT
     pub fn is_halted(&self) -> bool {
-        self.state.halted  && !self.state.nmi_pending
+        self.state.halted && !self.state.nmi_pending && !self.state.reset_pending
     }
 
     /// Non maskable interrupt request
     pub fn signal_nmi(&mut self) {
         self.state.nmi_pending = true
+    }
+
+    /// Signal reset
+    pub fn signal_reset(&mut self) {
+        self.state.reset_pending = true
     }
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -11,6 +11,8 @@ pub struct State {
     pub halted: bool,
     /// Non maskable interrupt signaled
     pub nmi_pending: bool,
+    /// Reset signaled
+    pub reset_pending: bool,
     // Alternate index management
     pub index: Reg16, // Using HL, IX or IY
     pub displacement: i8, // Used for (IX+d) and (iY+d)
@@ -24,6 +26,7 @@ impl State {
             reg: Registers::new(),
             halted: false,
             nmi_pending: false,
+            reset_pending: false,
             index: Reg16::HL,
             displacement: 0,
             displacement_loaded: false,


### PR DESCRIPTION
I needed to add a reset signal. Please double check because I'm new to the z80. I followed what I read on [the manual](https://www.zilog.com/force_download.php?filepath=YUhSMGNEb3ZMM2QzZHk1NmFXeHZaeTVqYjIwdlpHOWpjeTk2T0RBdlZVMHdNRGd3TG5Ca1pnPT0=):
![image](https://user-images.githubusercontent.com/6921727/211217304-a41724a9-f7cc-4206-bf38-6abbd45f53f2.png)
